### PR TITLE
Store the understeer factor for generic car

### DIFF
--- a/irFFB/settings.cpp
+++ b/irFFB/settings.cpp
@@ -456,7 +456,7 @@ void Settings::writeGenericSettings() {
     setRegSetting(key, L"minForce", getMinForceSetting());
     setRegSetting(key, L"use360ForDirect", use360ForDirect);
 	setRegSetting(key, L"understeerFactor", understeerFactor);
-	setRegSetting(key, L"understeerOffset", understeerFactor);
+	setRegSetting(key, L"understeerOffset", understeerOffset);
 
     RegCloseKey(key);
 

--- a/irFFB/settings.cpp
+++ b/irFFB/settings.cpp
@@ -455,6 +455,8 @@ void Settings::writeGenericSettings() {
     setRegSetting(key, L"maxForce", maxForce);
     setRegSetting(key, L"minForce", getMinForceSetting());
     setRegSetting(key, L"use360ForDirect", use360ForDirect);
+	setRegSetting(key, L"understeerFactor", understeerFactor);
+	setRegSetting(key, L"understeerOffset", understeerFactor);
 
     RegCloseKey(key);
 


### PR DESCRIPTION
Save the desired understeer factor and offset to the registrey settings along with the rest of the "generic car" settings.